### PR TITLE
🐛 FIX: .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .env
-config/_pycache_
+config/__pycache__


### PR DESCRIPTION
Alors j'ai changé le .git ignore car j'ai voulu ajouté le cache python au git ignore donc j'ai noté _pycache_ mais au final c'était __pycache__ (vraiment une erreur débile)